### PR TITLE
Add a `demo` target to the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ var/
 /build/
 /local/
 /.tox/
+/demo/venv/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,13 @@ test: bin/python
 	bin/tox
 
 clean:
-	rm -rf bin .tox include/ lib/ man/ django_chartjs.egg-info/ build/
+	rm -rf bin .tox include/ lib/ man/ django_chartjs.egg-info/ build/ demo/venv/
 
 docs:
 	(cd docs; make html)
+
+.PHONY: demo
+demo:
+	test -d demo/venv || virtualenv demo/venv
+	demo/venv/bin/pip install -e demo
+	DJANGO_SETTINGS_MODULE=demoproject.settings demo/venv/bin/python demo/demoproject/manage.py runserver


### PR DESCRIPTION
... that installs Django+deps and runs the demo project server

Fixes #10 

wfm but code review for non-OSX platforms gratefully accepted