### PR TITLE
Refs CS-976 -- Adding get_x_axis_options to get something symmetric.

### DIFF
--- a/chartjs/views/lines.py
+++ b/chartjs/views/lines.py
@@ -55,13 +55,16 @@ class HighchartPlotLineChartView(HighChartsView):
     def get_y_axis_options(self):
         return {'title': {'text': u'%s' % self.y_axis_title}}
 
+    def get_x_axis_options(self):
+        return {"categories": self.get_labels()}
+
     def get_context_data(self, **kwargs):
         data = super(HighchartPlotLineChartView, self).get_context_data(**kwargs)
         data.update({
             'labels': self.get_labels(),
-            'xAxis': {"categories": self.get_labels()},
+            'xAxis': self.get_x_axis_options(),
             'series': self.get_series(),
-            'yAxis': self.get_y_axis_options()
+            'yAxis': self.get_y_axis_options(),
         })
         return data
 


### PR DESCRIPTION
For issue [CS-976](https://people-doc.atlassian.net/browse/CS-976), I had to add some extra options to the x axis, and I discovered that class have a simple way to add yAxis options, but not xAxis.

So here it is!