### PR TITLE
Allow users to specify chart options in the view

### DIFF
--- a/chartjs/views/lines.py
+++ b/chartjs/views/lines.py
@@ -49,6 +49,23 @@ class BaseLineChartView(JSONView):
         return []
 
 
+class BaseLineOptionsChartView(BaseLineChartView):
+    def get_context_data(self, **kwargs):
+        context = super(BaseLineChartView, self).get_context_data(**kwargs)
+        context.update({
+            'data': {
+                'labels': self.get_labels(),
+                'datasets': self.get_datasets(),
+            },
+            'options': self.get_options(),
+        })
+        return context
+
+    def get_options(self):
+        raise NotImplementedError(  # pragma: no cover
+            'You should return a dict. '
+            '(i.e.: {"responsive": false})')
+
 class HighchartPlotLineChartView(HighChartsView):
     y_axis_title = None
 

--- a/demo/demoproject/templates/line_chart.html
+++ b/demo/demoproject/templates/line_chart.html
@@ -48,6 +48,21 @@
       });
   </script>
 
+  <h2>Chart.js Line Chart with options specified in view</h2>
+
+  <canvas id="lineChartWithOptions" width="500" height="500"></canvas>
+
+  <script type="text/javascript">
+    $.get('{% url 'line_chart_with_options' %}', function (data) {
+        var ctx = $("#lineChartWithOptions").get(0).getContext("2d");
+        new Chart(ctx, {
+            type: 'line',
+            data: data.data,
+            options: data.options,
+        });
+    });
+</script>
+
   <h2>HighCharts</h2>
 
   <div id="myHighChart" style="height: 500px; width: 500px;"></div>

--- a/demo/demoproject/tests.py
+++ b/demo/demoproject/tests.py
@@ -118,3 +118,16 @@ class DiscontinuousDataTestCase(TestCase):
         expected_data = [10, 12, 13, 15, NULL, NULL, 16, 18, 20, 21]
         self.assertEqual(actual_data, expected_data)
 
+
+class ChartOptionsTestCase(TestCase):
+    def test_line_chart_with_options_json(self):
+        resp = self.client.get(reverse('line_chart_with_options'))
+        try:
+            data = json.loads(decode(resp.content))
+        except ValueError:
+            self.fail("%r is not valid json" % self.resp.content)
+        self.assertIn('data', data)
+        self.assertIn('datasets', data['data'])
+        self.assertIn('labels', data['data'])
+        self.assertIn('options', data)
+        self.assertIn('title', data['options'])

--- a/demo/demoproject/urls.py
+++ b/demo/demoproject/urls.py
@@ -26,10 +26,13 @@ patterns_list = [
         name='line_chart_json'),
     url(r'^line_chart/discontinuous/json/$', views.discontinuous_dates_chart_json,
         name='discontinuous_line_chart_json'),
+    url(r'^line_chart/options/$', views.line_chart_with_options,
+        name='line_chart_with_options'),
     url(r'^line_highchart/json/$', views.line_highchart_json,
         name='line_highchart_json'),
     url(r'^line_highchart/discontinuous/json/$', views.discontinuous_dates_highchart_json,
         name='discontinuous_line_highchart_json'),
+
 
     # Pie
     url(r'^pie_highchart/json/$', views.pie_highchart_json,

--- a/demo/demoproject/views.py
+++ b/demo/demoproject/views.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from chartjs.colors import next_color, COLORS
 from chartjs.views.columns import BaseColumnsHighChartsView
-from chartjs.views.lines import BaseLineChartView, HighchartPlotLineChartView
+from chartjs.views.lines import BaseLineChartView, BaseLineOptionsChartView, HighchartPlotLineChartView
 from chartjs.views.pie import HighChartPieView, HighChartDonutView
 from chartjs.util import date_range, value_or_null
 
@@ -123,6 +123,23 @@ class DiscontinuousDatesHighChartJSONView(ChartMixin, HighchartPlotLineChartView
         result.append(data)
         return result
 
+class LineChartWithOptionsJSONView(ChartMixin, BaseLineOptionsChartView):
+    def get_options(self):
+        options = {
+            "title": {
+                "display": True,
+                "text": 'Custom Chart Title',
+            },
+            "elements": {
+                "point": {
+                    "pointStyle": "rectRounded",
+                    "radius": 10,
+                },
+            },
+            "responsive": False,
+        }
+        return options
+
 
 # Pre-configured views.
 colors = ColorsView.as_view()
@@ -135,3 +152,4 @@ pie_highchart_json = PieHighChartJSONView.as_view()
 donut_highchart_json = DonutHighChartJSONView.as_view()
 discontinuous_dates_chart_json = DiscontinuousDatesChartJSONView.as_view()
 discontinuous_dates_highchart_json = DiscontinuousDatesHighChartJSONView.as_view()
+line_chart_with_options = LineChartWithOptionsJSONView.as_view()


### PR DESCRIPTION
Allow users to provide chart option in the view rather than the
template. Then, in the template, write

    $.get('{% url 'line_chart_with_options' %}', function (data) {
        var ctx = $("#lineChartWithOptions").get(0).getContext("2d");
        new Chart(ctx, {
            type: 'line',
            data: data.data,
            options: data.options,
        });
    });