### PR TITLE
On Django>=1.10 (maybe even 1.9) {% load static %} should be used ins…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ A simple Line Chart example.
 
 .. code-block:: html
 
-    {% load staticfiles %}
+    {% load static %}
     <html>
         <head>
             <title>django-chartjs line chart demo</title>


### PR DESCRIPTION
…tead of {% load static files %}